### PR TITLE
Fix prompt form reset after editing

### DIFF
--- a/frontend/src/components/PromptForm.tsx
+++ b/frontend/src/components/PromptForm.tsx
@@ -14,13 +14,15 @@ const defaultValues: PromptInput = {
 };
 
 export function PromptForm({ initialValues, onSubmit, submitLabel = 'Save Prompt' }: PromptFormProps) {
-  const [values, setValues] = useState<PromptInput>(initialValues ?? defaultValues);
+  const [values, setValues] = useState<PromptInput>(initialValues ?? { ...defaultValues });
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (initialValues) {
       setValues(initialValues);
+    } else {
+      setValues({ ...defaultValues });
     }
   }, [initialValues]);
 
@@ -35,7 +37,7 @@ export function PromptForm({ initialValues, onSubmit, submitLabel = 'Save Prompt
     try {
       await onSubmit(values);
       if (!initialValues) {
-        setValues(defaultValues);
+        setValues({ ...defaultValues });
       }
     } catch (err) {
       setError((err as Error).message);


### PR DESCRIPTION
## Summary
- reset the prompt form values to a clean slate whenever editing mode is cleared
- clone the default prompt template when initializing or resetting state to avoid stale references

## Testing
- not run (npm install fails to download @prisma/client due to 403 from registry)


------
https://chatgpt.com/codex/tasks/task_b_68da4b5c2928832795743ed2be6da2dd